### PR TITLE
hinge.1.md: clarify that visuali{z,s}e are two forms of the same command

### DIFF
--- a/src/hinge.1.md
+++ b/src/hinge.1.md
@@ -42,5 +42,5 @@ Run each subcommand without arguments for usage information.
 **gfa**
 :    Create a graphical fragment assembly file from **consensus** output
 
-**visualize** **visualise**
+**visualize**, **visualise**
 


### PR DESCRIPTION
This is really minor, but it was bothering me a bit since I hadn't written it in the format of traditional manpages, where commas delimit equivalent forms of the same argument.